### PR TITLE
Made the "lead" text editable.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -39,8 +39,18 @@
                 <div class = "intro-grid">
                     <div>
                         <h2 id = "intro-title">Hi, I'm Mari! 👋</h2>
-                        <p class = "lead">Just another college student trying her best. Storyteller, D&D Enthusiast, Unfiction Enjoyer.</p>
-                        <a class = "btn" href="#projects"> See my work</a>
+                        <p class="lead-edit-wrapper">
+                            <span class="lead" id="lead-text">
+                                Just another college student trying her best. Storyteller, D&D Enthusiast, Unfiction Enjoyer.
+                            </span>
+                            <button class="edit-lead-btn" aria-label="Edit lead text" tabindex="-1">
+                                <!-- Pencil SVG icon -->
+                                <svg width="18" height="18" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+                                    <path d="M14.7 3.29a1 1 0 0 1 1.42 0l.59.59a1 1 0 0 1 0 1.42l-9.3 9.3-2.12.7.7-2.12 9.3-9.3z" stroke="currentColor" stroke-width="1.5" fill="none"/>
+                                </svg>
+                            </button>
+                        </p>
+                        <a class = "btn" id = "proj-btn" href="#projects"> See my work</a>
                     </div>
                     <figure class = "profile">
                         <img src="images/Yuna2.png" alt="Mari Montero's online avatar: a green alien wearing a flower crown and holding up a peace sign against a pink background.">
@@ -169,5 +179,20 @@
     <footer class = "site-footer">
         © <span id = "year">2025</span> Mari Montero - Built with HTML & CSS
     </footer>
+
+    <!-- Lead Text Edit Modal -->
+    <div id="lead-modal" class="modal" aria-modal="true" role="dialog" aria-labelledby="lead-modal-title" hidden>
+        <div class="modal-content">
+            <h3 id="lead-modal-title">Edit Lead Text</h3>
+            <form id="lead-modal-form">
+                <textarea id="lead-modal-input" rows="3" maxlength="120"></textarea>
+                <div class="modal-actions">
+                    <button type="submit" class="btn">Save</button>
+                    <button type="button" class="btn btn-outline" id="lead-modal-cancel">Cancel</button>
+                </div>
+            </form>
+        </div>
+    </div>
+    <!-- End of Lead Text Edit Modal -->
 </body>
 </html>

--- a/docs/script.js
+++ b/docs/script.js
@@ -8,3 +8,53 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     });
 });
+
+document.addEventListener('DOMContentLoaded', function() {
+    // Color toggle
+    const toggle = document.getElementById('color-toggle');
+    toggle.addEventListener('change', function() {
+        if (toggle.checked) {
+            document.documentElement.setAttribute('data-theme', 'light');
+        } else {
+            document.documentElement.removeAttribute('data-theme');
+        }
+    });
+
+    // Lead modal logic
+    const leadBtn = document.querySelector('.edit-lead-btn');
+    const leadText = document.getElementById('lead-text');
+    const modal = document.getElementById('lead-modal');
+    const modalInput = document.getElementById('lead-modal-input');
+    const modalForm = document.getElementById('lead-modal-form');
+    const modalCancel = document.getElementById('lead-modal-cancel');
+    const defaultLead = leadText.textContent.trim();
+
+    // Open modal
+    leadBtn.addEventListener('click', function() {
+        modal.removeAttribute('hidden');
+        modalInput.value = leadText.textContent.trim();
+        modalInput.focus();
+    });
+
+    // Save new lead text
+    modalForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        leadText.textContent = modalInput.value.trim() || defaultLead;
+        modal.setAttribute('hidden', '');
+        leadBtn.focus();
+    });
+
+    // Cancel editing
+    modalCancel.addEventListener('click', function() {
+        modal.setAttribute('hidden', '');
+        leadBtn.focus();
+    });
+
+    // Close modal on Escape key
+    modal.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') {
+            modal.setAttribute('hidden', '');
+            leadBtn.focus();
+        }
+    });
+});

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -162,9 +162,44 @@ a:hover {
     align-items: center;
 }
 
-.lead {
+/* Lead Edit Elements */
+.lead-edit-wrapper {
+    display: inline-block;
+    position: relative;
+}
+
+.edit-lead-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: none;
+    border: none;
     color: var(--muted);
-    max-width: 55ch;
+    margin-left: 0.4em;
+    padding: 2px;
+    border-radius: 4px;
+    cursor: pointer;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.15s;
+    font-size: 1em;
+}
+
+.lead-edit-wrapper:hover .edit-lead-btn,
+.edit-lead-btn:focus {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.edit-lead-btn svg {
+    display: block;
+    width: 1em;
+    height: 1em;
+}
+
+.edit-lead-btn:focus {
+    outline: 2px solid var(--brand);
+    outline-offset: 2px;
 }
 
 .profile figcaption {
@@ -172,6 +207,62 @@ a:hover {
     font-size: .9rem;
     margin-top: 5px;
     text-align: center;
+}
+
+#proj-btn {
+    display: block;
+    margin-top: 1.2rem;
+    width: fit-content;
+}
+
+.modal {
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.45);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+.modal[hidden] {
+    display: none;
+}
+
+.modal-content {
+    background: var(--panel);
+    color: var(--text);
+    border-radius: var(--radius);
+    padding: 2rem 1.5rem 1.2rem 1.5rem;
+    min-width: 320px;
+    max-width: 90vw;
+    box-shadow: 0 8px 32px rgba(0,0,0,0.18);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.modal-content h3 {
+    margin: 0 0 .5rem 0;
+    font-size: 1.1rem;
+}
+
+#lead-modal-input {
+    width: 100%;
+    border-radius: 8px;
+    border: 1px solid var(--muted);
+    padding: .7rem;
+    font-size: 1rem;
+    color: var(--text);
+    background: var(--bg);
+    resize: vertical;
+}
+
+.modal-actions {
+    display: flex;
+    gap: .7rem;
+    justify-content: flex-end;
+    margin-top: .5rem;
 }
 
 /* Buttons */


### PR DESCRIPTION
Truthfully, this shouldn't be a feature as this site _has_ no login functionality. As a portfolio page, no one should be able to publicly edit any of these text fields. Alas, the exercise that requires this feature, well, _requires_ it. And so, it stays.

As such, I've limited it to just the lead text as a little fun showcase of JavaScript at work. This editable change will not remain between page refreshes to avoid caching content on the user's system.